### PR TITLE
Fix 删除 `$dispatch->afterResponse();`，解决在某些情况下队列仍是同步执行

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -111,7 +111,7 @@ md;
                 })
             ));
 
-            method_exists($dispatch, 'afterResponse') && $dispatch->afterResponse();
+            // method_exists($dispatch, 'afterResponse') && $dispatch->afterResponse();
         } catch (Throwable $e) {
             Log::error($e->getMessage());
         }


### PR DESCRIPTION
即使 `.env` 里配置的 `QUEUE_CONNECTION=redis`，也无效

详细讨论见：https://github.com/guanguans/laravel-exception-notify/issues/8