### PR TITLE
Fix 解决即使 `.env` 里配置的 `QUEUE_CONNECTION=redis`, 某些情况下队列仍是同步执行

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -111,7 +111,7 @@ md;
                 })
             ));
 
-            method_exists($dispatch, 'afterResponse') && $dispatch->afterResponse();
+            config('queue.default') === 'sync' and method_exists($dispatch, 'afterResponse') and $dispatch->afterResponse();
         } catch (Throwable $e) {
             Log::error($e->getMessage());
         }


### PR DESCRIPTION
详细讨论见：https://github.com/guanguans/laravel-exception-notify/issues/8